### PR TITLE
Force precompilation on rhs! MethodInstances

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Michael Schlottke-Lakemper <michael@sloede.com>"]
 version = "0.1.0"
 
 [deps]
+MethodAnalysis = "85b6ec6f-f7df-4429-9514-a64bcd9ee824"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"

--- a/src/TrixiStartup.jl
+++ b/src/TrixiStartup.jl
@@ -2,6 +2,7 @@ module TrixiStartup
 
 using PrecompileTools: @compile_workload
 using Reexport: @reexport
+using MethodAnalysis
 
 @reexport using OrdinaryDiffEq
 @reexport using Trixi
@@ -70,6 +71,15 @@ using Reexport: @reexport
                 initial_refinement_level=1,
                 polydeg=4,
                )
+end
+
+for mi in methodinstances()
+    mi.def.name === :rhs! || continue
+    try
+        precompile(mi.specTypes)
+    catch e
+        @warn "Precompilation failed for $mi with $(e)"
+    end
 end
 
 end


### PR DESCRIPTION
These do not end up being force-precompiled, possibly due
to `trixi_include`. It is not entirely clear why.

This drops the time for the first `trixi_include` by about a factor of 5.