### PR TITLE
Replace `trixi_include`s with corresponding `include`s

### DIFF
--- a/precompile/p4est_2d_dgsem_elixir_euler_shockcapturing_ec_polydeg3.jl
+++ b/precompile/p4est_2d_dgsem_elixir_euler_shockcapturing_ec_polydeg3.jl
@@ -1,0 +1,72 @@
+
+# using OrdinaryDiffEq
+# using Trixi
+
+###############################################################################
+# semidiscretization of the compressible Euler equations
+
+equations = CompressibleEulerEquations2D(1.4)
+
+initial_condition = initial_condition_weak_blast_wave
+
+surface_flux = flux_ranocha
+volume_flux = flux_ranocha
+polydeg = 3
+basis = LobattoLegendreBasis(polydeg)
+indicator_sc = IndicatorHennemannGassner(equations, basis,
+                                         alpha_max=1.0,
+                                         alpha_min=0.001,
+                                         alpha_smooth=true,
+                                         variable=density_pressure)
+volume_integral = VolumeIntegralShockCapturingHG(indicator_sc;
+                                                 volume_flux_dg=volume_flux,
+                                                 volume_flux_fv=surface_flux)
+
+solver = DGSEM(polydeg=polydeg, surface_flux=surface_flux, volume_integral=volume_integral)
+
+###############################################################################
+
+coordinates_min = (-1.0, -1.0)
+coordinates_max = ( 1.0,  1.0)
+
+trees_per_dimension = (4, 4)
+mesh = P4estMesh(trees_per_dimension,
+                 polydeg=3, initial_refinement_level=0,
+                 coordinates_min=coordinates_min, coordinates_max=coordinates_max,
+                 periodicity=true)
+
+semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver)
+
+
+###############################################################################
+# ODE solvers, callbacks etc.
+
+tspan = (0.0, 0.01)
+ode = semidiscretize(semi, tspan)
+
+summary_callback = SummaryCallback()
+
+analysis_interval = 100
+analysis_callback = AnalysisCallback(semi, interval=analysis_interval)
+
+alive_callback = AliveCallback(analysis_interval=analysis_interval)
+
+save_solution = SaveSolutionCallback(interval=100,
+                                     save_initial_solution=true,
+                                     save_final_solution=true,
+                                     solution_variables=cons2prim)
+
+stepsize_callback = StepsizeCallback(cfl=1.0)
+
+callbacks = CallbackSet(summary_callback,
+                        analysis_callback,
+                        alive_callback,
+                        save_solution,
+                        stepsize_callback)
+###############################################################################
+# run the simulation
+
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
+            dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
+            save_everystep=false, callback=callbacks);
+summary_callback() # print the timer summary

--- a/precompile/p4est_2d_dgsem_elixir_euler_shockcapturing_ec_polydeg4.jl
+++ b/precompile/p4est_2d_dgsem_elixir_euler_shockcapturing_ec_polydeg4.jl
@@ -1,0 +1,72 @@
+
+# using OrdinaryDiffEq
+# using Trixi
+
+###############################################################################
+# semidiscretization of the compressible Euler equations
+
+equations = CompressibleEulerEquations2D(1.4)
+
+initial_condition = initial_condition_weak_blast_wave
+
+surface_flux = flux_ranocha
+volume_flux = flux_ranocha
+polydeg = 4
+basis = LobattoLegendreBasis(polydeg)
+indicator_sc = IndicatorHennemannGassner(equations, basis,
+                                         alpha_max=1.0,
+                                         alpha_min=0.001,
+                                         alpha_smooth=true,
+                                         variable=density_pressure)
+volume_integral = VolumeIntegralShockCapturingHG(indicator_sc;
+                                                 volume_flux_dg=volume_flux,
+                                                 volume_flux_fv=surface_flux)
+
+solver = DGSEM(polydeg=polydeg, surface_flux=surface_flux, volume_integral=volume_integral)
+
+###############################################################################
+
+coordinates_min = (-1.0, -1.0)
+coordinates_max = ( 1.0,  1.0)
+
+trees_per_dimension = (4, 4)
+mesh = P4estMesh(trees_per_dimension,
+                 polydeg=4, initial_refinement_level=0,
+                 coordinates_min=coordinates_min, coordinates_max=coordinates_max,
+                 periodicity=true)
+
+semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver)
+
+
+###############################################################################
+# ODE solvers, callbacks etc.
+
+tspan = (0.0, 0.01)
+ode = semidiscretize(semi, tspan)
+
+summary_callback = SummaryCallback()
+
+analysis_interval = 100
+analysis_callback = AnalysisCallback(semi, interval=analysis_interval)
+
+alive_callback = AliveCallback(analysis_interval=analysis_interval)
+
+save_solution = SaveSolutionCallback(interval=100,
+                                     save_initial_solution=true,
+                                     save_final_solution=true,
+                                     solution_variables=cons2prim)
+
+stepsize_callback = StepsizeCallback(cfl=1.0)
+
+callbacks = CallbackSet(summary_callback,
+                        analysis_callback,
+                        alive_callback,
+                        save_solution,
+                        stepsize_callback)
+###############################################################################
+# run the simulation
+
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
+            dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
+            save_everystep=false, callback=callbacks);
+summary_callback() # print the timer summary

--- a/precompile/p4est_3d_dgsem_elixir_euler_source_terms_nonperiodic_polydeg3.jl
+++ b/precompile/p4est_3d_dgsem_elixir_euler_source_terms_nonperiodic_polydeg3.jl
@@ -1,0 +1,72 @@
+
+# using OrdinaryDiffEq
+# using Trixi
+
+###############################################################################
+# semidiscretization of the compressible Euler equations
+
+equations = CompressibleEulerEquations3D(1.4)
+
+initial_condition = initial_condition_convergence_test
+
+boundary_condition = BoundaryConditionDirichlet(initial_condition)
+boundary_conditions = Dict(
+  :x_neg => boundary_condition,
+  :x_pos => boundary_condition,
+  :y_neg => boundary_condition,
+  :y_pos => boundary_condition,
+  :z_neg => boundary_condition,
+  :z_pos => boundary_condition
+)
+
+solver = DGSEM(polydeg=3, surface_flux=flux_lax_friedrichs,
+               volume_integral=VolumeIntegralWeakForm())
+
+coordinates_min = (0.0, 0.0, 0.0)
+coordinates_max = (2.0, 2.0, 2.0)
+
+trees_per_dimension = (2, 2, 2)
+
+# mesh = P4estMesh(trees_per_dimension, polydeg=1,
+mesh = P4estMesh(trees_per_dimension, polydeg=3,
+                 coordinates_min=coordinates_min, coordinates_max=coordinates_max,
+                 periodicity=false, initial_refinement_level=0)
+
+semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
+                                    source_terms=source_terms_convergence_test,
+                                    boundary_conditions=boundary_conditions)
+
+
+###############################################################################
+# ODE solvers, callbacks etc.
+
+tspan = (0.0, 0.01)
+ode = semidiscretize(semi, tspan)
+
+summary_callback = SummaryCallback()
+
+analysis_interval = 100
+analysis_callback = AnalysisCallback(semi, interval=analysis_interval)
+
+alive_callback = AliveCallback(analysis_interval=analysis_interval)
+
+save_solution = SaveSolutionCallback(interval=100,
+                                     save_initial_solution=true,
+                                     save_final_solution=true,
+                                     solution_variables=cons2prim)
+
+stepsize_callback = StepsizeCallback(cfl=0.6)
+
+callbacks = CallbackSet(summary_callback,
+                        analysis_callback, alive_callback,
+                        save_solution,
+                        stepsize_callback)
+
+
+###############################################################################
+# run the simulation
+
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
+            dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
+            save_everystep=false, callback=callbacks);
+summary_callback() # print the timer summary

--- a/precompile/p4est_3d_dgsem_elixir_euler_source_terms_nonperiodic_polydeg4.jl
+++ b/precompile/p4est_3d_dgsem_elixir_euler_source_terms_nonperiodic_polydeg4.jl
@@ -1,0 +1,72 @@
+
+# using OrdinaryDiffEq
+# using Trixi
+
+###############################################################################
+# semidiscretization of the compressible Euler equations
+
+equations = CompressibleEulerEquations3D(1.4)
+
+initial_condition = initial_condition_convergence_test
+
+boundary_condition = BoundaryConditionDirichlet(initial_condition)
+boundary_conditions = Dict(
+  :x_neg => boundary_condition,
+  :x_pos => boundary_condition,
+  :y_neg => boundary_condition,
+  :y_pos => boundary_condition,
+  :z_neg => boundary_condition,
+  :z_pos => boundary_condition
+)
+
+solver = DGSEM(polydeg=4, surface_flux=flux_lax_friedrichs,
+               volume_integral=VolumeIntegralWeakForm())
+
+coordinates_min = (0.0, 0.0, 0.0)
+coordinates_max = (2.0, 2.0, 2.0)
+
+trees_per_dimension = (2, 2, 2)
+
+# mesh = P4estMesh(trees_per_dimension, polydeg=1,
+mesh = P4estMesh(trees_per_dimension, polydeg=4,
+                 coordinates_min=coordinates_min, coordinates_max=coordinates_max,
+                 periodicity=false, initial_refinement_level=0)
+
+semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
+                                    source_terms=source_terms_convergence_test,
+                                    boundary_conditions=boundary_conditions)
+
+
+###############################################################################
+# ODE solvers, callbacks etc.
+
+tspan = (0.0, 0.01)
+ode = semidiscretize(semi, tspan)
+
+summary_callback = SummaryCallback()
+
+analysis_interval = 100
+analysis_callback = AnalysisCallback(semi, interval=analysis_interval)
+
+alive_callback = AliveCallback(analysis_interval=analysis_interval)
+
+save_solution = SaveSolutionCallback(interval=100,
+                                     save_initial_solution=true,
+                                     save_final_solution=true,
+                                     solution_variables=cons2prim)
+
+stepsize_callback = StepsizeCallback(cfl=0.6)
+
+callbacks = CallbackSet(summary_callback,
+                        analysis_callback, alive_callback,
+                        save_solution,
+                        stepsize_callback)
+
+
+###############################################################################
+# run the simulation
+
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
+            dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
+            save_everystep=false, callback=callbacks);
+summary_callback() # print the timer summary

--- a/precompile/tree_2d_dgsem_elixir_euler_ec_polydeg3.jl
+++ b/precompile/tree_2d_dgsem_elixir_euler_ec_polydeg3.jl
@@ -1,0 +1,59 @@
+
+# using OrdinaryDiffEq
+# using Trixi
+
+###############################################################################
+# semidiscretization of the compressible Euler equations
+equations = CompressibleEulerEquations2D(1.4)
+
+initial_condition = initial_condition_weak_blast_wave
+
+volume_flux = flux_ranocha
+solver = DGSEM(polydeg=3, surface_flux=flux_ranocha,
+               volume_integral=VolumeIntegralFluxDifferencing(volume_flux))
+
+coordinates_min = (-2.0, -2.0)
+coordinates_max = ( 2.0,  2.0)
+mesh = TreeMesh(coordinates_min, coordinates_max,
+                initial_refinement_level=1,
+                n_cells_max=10_000,
+                periodicity=true)
+
+
+semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
+                                    boundary_conditions=boundary_condition_periodic)
+
+
+###############################################################################
+# ODE solvers, callbacks etc.
+
+tspan = (0.0, 0.01)
+ode = semidiscretize(semi, tspan)
+
+summary_callback = SummaryCallback()
+
+analysis_interval = 100
+analysis_callback = AnalysisCallback(semi, interval=analysis_interval)
+
+alive_callback = AliveCallback(analysis_interval=analysis_interval)
+
+save_solution = SaveSolutionCallback(interval=100,
+                                     save_initial_solution=true,
+                                     save_final_solution=true,
+                                     solution_variables=cons2prim)
+
+stepsize_callback = StepsizeCallback(cfl=1.0)
+
+callbacks = CallbackSet(summary_callback,
+                        analysis_callback, alive_callback,
+                        save_solution,
+                        stepsize_callback)
+
+
+###############################################################################
+# run the simulation
+
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
+            dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
+            save_everystep=false, callback=callbacks);
+summary_callback() # print the timer summary

--- a/precompile/tree_2d_dgsem_elixir_euler_ec_polydeg4.jl
+++ b/precompile/tree_2d_dgsem_elixir_euler_ec_polydeg4.jl
@@ -1,0 +1,59 @@
+
+# using OrdinaryDiffEq
+# using Trixi
+
+###############################################################################
+# semidiscretization of the compressible Euler equations
+equations = CompressibleEulerEquations2D(1.4)
+
+initial_condition = initial_condition_weak_blast_wave
+
+volume_flux = flux_ranocha
+solver = DGSEM(polydeg=4, surface_flux=flux_ranocha,
+               volume_integral=VolumeIntegralFluxDifferencing(volume_flux))
+
+coordinates_min = (-2.0, -2.0)
+coordinates_max = ( 2.0,  2.0)
+mesh = TreeMesh(coordinates_min, coordinates_max,
+                initial_refinement_level=1,
+                n_cells_max=10_000,
+                periodicity=true)
+
+
+semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
+                                    boundary_conditions=boundary_condition_periodic)
+
+
+###############################################################################
+# ODE solvers, callbacks etc.
+
+tspan = (0.0, 0.01)
+ode = semidiscretize(semi, tspan)
+
+summary_callback = SummaryCallback()
+
+analysis_interval = 100
+analysis_callback = AnalysisCallback(semi, interval=analysis_interval)
+
+alive_callback = AliveCallback(analysis_interval=analysis_interval)
+
+save_solution = SaveSolutionCallback(interval=100,
+                                     save_initial_solution=true,
+                                     save_final_solution=true,
+                                     solution_variables=cons2prim)
+
+stepsize_callback = StepsizeCallback(cfl=1.0)
+
+callbacks = CallbackSet(summary_callback,
+                        analysis_callback, alive_callback,
+                        save_solution,
+                        stepsize_callback)
+
+
+###############################################################################
+# run the simulation
+
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
+            dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
+            save_everystep=false, callback=callbacks);
+summary_callback() # print the timer summary

--- a/precompile/tree_3d_dgsem_elixir_euler_ec_polydeg3.jl
+++ b/precompile/tree_3d_dgsem_elixir_euler_ec_polydeg3.jl
@@ -1,0 +1,58 @@
+
+# using OrdinaryDiffEq
+# using Trixi
+
+###############################################################################
+# semidiscretization of the compressible Euler equations
+
+equations = CompressibleEulerEquations3D(1.4)
+
+initial_condition = initial_condition_weak_blast_wave
+
+volume_flux = flux_ranocha
+solver = DGSEM(polydeg=3, surface_flux=flux_ranocha,
+               volume_integral=VolumeIntegralFluxDifferencing(volume_flux))
+
+coordinates_min = (-2.0, -2.0, -2.0)
+coordinates_max = ( 2.0,  2.0,  2.0)
+mesh = TreeMesh(coordinates_min, coordinates_max,
+                initial_refinement_level=1,
+                n_cells_max=100_000)
+
+
+semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver)
+
+
+###############################################################################
+# ODE solvers, callbacks etc.
+
+tspan = (0.0, 0.01)
+ode = semidiscretize(semi, tspan)
+
+summary_callback = SummaryCallback()
+
+analysis_interval = 100
+analysis_callback = AnalysisCallback(semi, interval=analysis_interval)
+
+alive_callback = AliveCallback(analysis_interval=analysis_interval)
+
+save_solution = SaveSolutionCallback(interval=100,
+                                     save_initial_solution=true,
+                                     save_final_solution=true,
+                                     solution_variables=cons2prim)
+
+stepsize_callback = StepsizeCallback(cfl=1.3)
+
+callbacks = CallbackSet(summary_callback,
+                        analysis_callback, alive_callback,
+                        save_solution,
+                        stepsize_callback)
+
+
+###############################################################################
+# run the simulation
+
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
+            dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
+            save_everystep=false, callback=callbacks);
+summary_callback() # print the timer summary

--- a/precompile/tree_3d_dgsem_elixir_euler_ec_polydeg4.jl
+++ b/precompile/tree_3d_dgsem_elixir_euler_ec_polydeg4.jl
@@ -1,0 +1,58 @@
+
+# using OrdinaryDiffEq
+# using Trixi
+
+###############################################################################
+# semidiscretization of the compressible Euler equations
+
+equations = CompressibleEulerEquations3D(1.4)
+
+initial_condition = initial_condition_weak_blast_wave
+
+volume_flux = flux_ranocha
+solver = DGSEM(polydeg=4, surface_flux=flux_ranocha,
+               volume_integral=VolumeIntegralFluxDifferencing(volume_flux))
+
+coordinates_min = (-2.0, -2.0, -2.0)
+coordinates_max = ( 2.0,  2.0,  2.0)
+mesh = TreeMesh(coordinates_min, coordinates_max,
+                initial_refinement_level=1,
+                n_cells_max=100_000)
+
+
+semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver)
+
+
+###############################################################################
+# ODE solvers, callbacks etc.
+
+tspan = (0.0, 0.01)
+ode = semidiscretize(semi, tspan)
+
+summary_callback = SummaryCallback()
+
+analysis_interval = 100
+analysis_callback = AnalysisCallback(semi, interval=analysis_interval)
+
+alive_callback = AliveCallback(analysis_interval=analysis_interval)
+
+save_solution = SaveSolutionCallback(interval=100,
+                                     save_initial_solution=true,
+                                     save_final_solution=true,
+                                     solution_variables=cons2prim)
+
+stepsize_callback = StepsizeCallback(cfl=1.3)
+
+callbacks = CallbackSet(summary_callback,
+                        analysis_callback, alive_callback,
+                        save_solution,
+                        stepsize_callback)
+
+
+###############################################################################
+# run the simulation
+
+sol = solve(ode, CarpenterKennedy2N54(williamson_condition=false),
+            dt=1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
+            save_everystep=false, callback=callbacks);
+summary_callback() # print the timer summary

--- a/src/TrixiStartup.jl
+++ b/src/TrixiStartup.jl
@@ -8,68 +8,28 @@ using Reexport: @reexport
 
 @compile_workload begin
   # Compressible Euler, P4estMesh, 2D, polydeg=3
-  trixi_include(@__MODULE__,
-                joinpath("..", "precompile", "p4est_2d_dgsem_elixir_euler_shockcapturing_ec.jl"),
-                tspan=(0.0, 0.01),
-                initial_refinement_level=0,
-                polydeg=3,
-               )
+  include(joinpath("..", "precompile", "p4est_2d_dgsem_elixir_euler_shockcapturing_ec_polydeg3.jl"))
 
   # Compressible Euler, P4estMesh, 2D, polydeg=4
-  trixi_include(@__MODULE__,
-                joinpath("..", "precompile", "p4est_2d_dgsem_elixir_euler_shockcapturing_ec.jl"),
-                tspan=(0.0, 0.01),
-                initial_refinement_level=0,
-                polydeg=4,
-               )
+  include(joinpath("..", "precompile", "p4est_2d_dgsem_elixir_euler_shockcapturing_ec_polydeg4.jl"))
 
   # Compressible Euler, P4estMesh, 3D, polydeg=3
-  trixi_include(@__MODULE__,
-                joinpath("..", "precompile", "p4est_3d_dgsem_elixir_euler_source_terms_nonperiodic.jl"),
-                tspan=(0.0, 0.01),
-                initial_refinement_level=0,
-                polydeg=3,
-               )
+  include(joinpath("..", "precompile", "p4est_3d_dgsem_elixir_euler_source_terms_nonperiodic_polydeg3.jl"))
 
   # Compressible Euler, P4estMesh, 3D, polydeg=4
-  trixi_include(@__MODULE__,
-                joinpath("..", "precompile", "p4est_3d_dgsem_elixir_euler_source_terms_nonperiodic.jl"),
-                tspan=(0.0, 0.01),
-                initial_refinement_level=0,
-                polydeg=4,
-               )
+  include(joinpath("..", "precompile", "p4est_3d_dgsem_elixir_euler_source_terms_nonperiodic_polydeg4.jl"))
 
   # Compressible Euler, TreeMesh, 2D, polydeg=3
-  trixi_include(@__MODULE__,
-                joinpath("..", "precompile", "tree_2d_dgsem_elixir_euler_ec.jl"),
-                tspan=(0.0, 0.01),
-                initial_refinement_level=1,
-                polydeg=3,
-               )
+  include(joinpath("..", "precompile", "tree_2d_dgsem_elixir_euler_ec_polydeg3.jl"))
 
   # Compressible Euler, TreeMesh, 2D, polydeg=4
-  trixi_include(@__MODULE__,
-                joinpath("..", "precompile", "tree_2d_dgsem_elixir_euler_ec.jl"),
-                tspan=(0.0, 0.01),
-                initial_refinement_level=1,
-                polydeg=4,
-               )
+  include(joinpath("..", "precompile", "tree_2d_dgsem_elixir_euler_ec_polydeg4.jl"))
 
   # Compressible Euler, TreeMesh, 3D, polydeg=3
-  trixi_include(@__MODULE__,
-                joinpath("..", "precompile", "tree_3d_dgsem_elixir_euler_ec.jl"),
-                tspan=(0.0, 0.01),
-                initial_refinement_level=1,
-                polydeg=3,
-               )
+  include(joinpath("..", "precompile", "tree_3d_dgsem_elixir_euler_ec_polydeg3.jl"))
 
   # Compressible Euler, TreeMesh, 3D, polydeg=4
-  trixi_include(@__MODULE__,
-                joinpath("..", "precompile", "tree_3d_dgsem_elixir_euler_ec.jl"),
-                tspan=(0.0, 0.01),
-                initial_refinement_level=1,
-                polydeg=4,
-               )
+  include(joinpath("..", "precompile", "tree_3d_dgsem_elixir_euler_ec_polydeg4.jl"))
 end
 
 end


### PR DESCRIPTION
In #5 it was noted that there might be a problem with some method instances not being properly precompiled, possibly due to whatever `trixi_include` does. I therefore replaced all `trixi_include`s by regular `include`s and adapted the setups accordingly, such that they correspond exactly to the code that was executed before.

However, with this PR I still have the same run times as in the current `main`:
```julia
julia> @time using TrixiStartup
  8.170874 seconds (14.93 M allocations: 989.338 MiB, 5.99% gc time, 8.92% compilation time: 24% of which was recompilation)

julia> @time include("../precompile/tree_2d_dgsem_elixir_euler_ec_polydeg3.jl")

[...]

 ────────────────────────────────────────────────────────────────────────────────────
              Trixi.jl                      Time                    Allocations
                                   ───────────────────────   ────────────────────────
         Tot / % measured:              7.23s /  99.2%            666MiB /  99.8%

 Section                   ncalls     time    %tot     avg     alloc    %tot      avg
 ────────────────────────────────────────────────────────────────────────────────────
 analyze solution               2    7.06s   98.5%   3.53s    665MiB  100.0%   332MiB
 I/O                            3    110ms    1.5%  36.6ms    156KiB    0.0%  52.0KiB
   ~I/O~                        3   96.9ms    1.4%  32.3ms    100KiB    0.0%  33.3KiB
   save solution                2   12.8ms    0.2%  6.41ms   51.0KiB    0.0%  25.5KiB
   get element variables        2   43.8μs    0.0%  21.9μs   5.16KiB    0.0%  2.58KiB
   save mesh                    2    380ns    0.0%   190ns     0.00B    0.0%    0.00B
 rhs!                           6   47.8μs    0.0%  7.97μs   9.33KiB    0.0%  1.55KiB
   volume integral              6   23.8μs    0.0%  3.96μs     0.00B    0.0%    0.00B
   ~rhs!~                       6   9.23μs    0.0%  1.54μs   9.33KiB    0.0%  1.55KiB
   interface flux               6   5.22μs    0.0%   870ns     0.00B    0.0%    0.00B
   prolong2interfaces           6   4.47μs    0.0%   745ns     0.00B    0.0%    0.00B
   surface integral             6   2.14μs    0.0%   357ns     0.00B    0.0%    0.00B
   Jacobian                     6    750ns    0.0%   125ns     0.00B    0.0%    0.00B
   reset ∂u/∂t                  6    690ns    0.0%   115ns     0.00B    0.0%    0.00B
   prolong2mortars              6    510ns    0.0%  85.0ns     0.00B    0.0%    0.00B
   prolong2boundaries           6    420ns    0.0%  70.0ns     0.00B    0.0%    0.00B
   mortar flux                  6    380ns    0.0%  63.3ns     0.00B    0.0%    0.00B
   source terms                 6    140ns    0.0%  23.3ns     0.00B    0.0%    0.00B
   boundary flux                6    120ns    0.0%  20.0ns     0.00B    0.0%    0.00B
 calculate dt                   2   1.43μs    0.0%   715ns     0.00B    0.0%    0.00B
 ────────────────────────────────────────────────────────────────────────────────────

  8.955083 seconds (15.06 M allocations: 867.116 MiB, 4.32% gc time, 99.51% compilation time: 8% of which was recompilation)

julia> @time include("../precompile/tree_2d_dgsem_elixir_euler_ec_polydeg3.jl")

[...]

 ────────────────────────────────────────────────────────────────────────────────────
              Trixi.jl                      Time                    Allocations
                                   ───────────────────────   ────────────────────────
         Tot / % measured:             2.49ms /  93.1%            121KiB /  88.0%

 Section                   ncalls     time    %tot     avg     alloc    %tot      avg
 ────────────────────────────────────────────────────────────────────────────────────
 I/O                            3   1.88ms   81.1%   628μs   62.2KiB   58.3%  20.7KiB
   save solution                2   1.17ms   50.5%   587μs   42.1KiB   39.4%  21.0KiB
   ~I/O~                        3    700μs   30.1%   233μs   15.5KiB   14.6%  5.18KiB
   get element variables        2   9.74μs    0.4%  4.87μs   4.59KiB    4.3%  2.30KiB
   save mesh                    2   60.0ns    0.0%  30.0ns     0.00B    0.0%    0.00B
 analyze solution               2    397μs   17.1%   198μs   35.2KiB   33.0%  17.6KiB
 rhs!                           6   40.9μs    1.8%  6.82μs   9.33KiB    8.7%  1.55KiB
   volume integral              6   21.7μs    0.9%  3.62μs     0.00B    0.0%    0.00B
   ~rhs!~                       6   8.71μs    0.4%  1.45μs   9.33KiB    8.7%  1.55KiB
   interface flux               6   4.28μs    0.2%   713ns     0.00B    0.0%    0.00B
   prolong2interfaces           6   3.08μs    0.1%   513ns     0.00B    0.0%    0.00B
   surface integral             6   1.61μs    0.1%   268ns     0.00B    0.0%    0.00B
   reset ∂u/∂t                  6    360ns    0.0%  60.0ns     0.00B    0.0%    0.00B
   Jacobian                     6    310ns    0.0%  51.7ns     0.00B    0.0%    0.00B
   prolong2mortars              6    240ns    0.0%  40.0ns     0.00B    0.0%    0.00B
   prolong2boundaries           6    200ns    0.0%  33.3ns     0.00B    0.0%    0.00B
   mortar flux                  6    180ns    0.0%  30.0ns     0.00B    0.0%    0.00B
   boundary flux                6    130ns    0.0%  21.7ns     0.00B    0.0%    0.00B
   source terms                 6    120ns    0.0%  20.0ns     0.00B    0.0%    0.00B
 calculate dt                   2    710ns    0.0%   355ns     0.00B    0.0%    0.00B
 ────────────────────────────────────────────────────────────────────────────────────

  0.010906 seconds (9.53 k allocations: 1.571 MiB)
```
For examples, this `include` corresponds exactly to
```julia
@time trixi_include("../precompile/tree_2d_dgsem_elixir_euler_ec.jl", tspan=(0.0, 0.01), initial_refinement_level=1, polydeg=3)
```

cc @timholy